### PR TITLE
Add English calendar parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 ## 🔧 Features
 
 - Detects meetings from your **Google Calendar** in **Week View**
+- Works with Google Calendar interfaces in **English** or **French**
 - Allows you to assign each meeting to a **project**
 - **Auto-links** recurring meetings to their projects using custom keywords
 - **Color-code** each project for clarity


### PR DESCRIPTION
## Summary
- support English times and dates in `content.js`
- note in README that English calendar interface is supported

## Testing
- `pre-commit` *(fails: no pre-commit setup)*

------
https://chatgpt.com/codex/tasks/task_e_6846fea621f8832394e56a7fcf58ccb5