### PR TITLE
Support h as time separator

### DIFF
--- a/content.js
+++ b/content.js
@@ -12,7 +12,7 @@ function parseEventsFromWeekView() {
     const info = chip.querySelector('.XuJrye');
     if (!info) return;
     const text = info.textContent.trim();
-    const match = text.match(/(?:from|de)?\s*(\d{1,2}(?::\d{2})?\s*(?:[ap]m)?)\s*(?:à|to|[-–])\s*(\d{1,2}(?::\d{2})?\s*(?:[ap]m)?),?\s*(.+)/i);
+    const match = text.match(/(?:from|de)?\s*(\d{1,2}(?:(?::|\s*h\s*)\d{2})?\s*(?:[ap]m)?)\s*(?:à|to|[-–])\s*(\d{1,2}(?:(?::|\s*h\s*)\d{2})?\s*(?:[ap]m)?),?\s*(.+)/i);
     if (!match) return;
     const [, start, end, title] = match;
 
@@ -51,7 +51,7 @@ function parseEventsFromWeekView() {
       lowerTitle.includes('pause')
     ) return;
     function toMinutes(str) {
-      const m = str.trim().toLowerCase().match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/);
+      const m = str.trim().toLowerCase().match(/(\d{1,2})(?:(?:\:|\s*h\s*)(\d{2}))?\s*(am|pm)?/);
       if (!m) return 0;
       let h = +m[1];
       const mins = m[2] ? +m[2] : 0;

--- a/regex_examples.js
+++ b/regex_examples.js
@@ -1,0 +1,29 @@
+const regex = /(?:from|de)?\s*(\d{1,2}(?:(?::|\s*h\s*)\d{2})?\s*(?:[ap]m)?)\s*(?:à|to|[-–])\s*(\d{1,2}(?:(?::|\s*h\s*)\d{2})?\s*(?:[ap]m)?),?\s*(.+)/i;
+function toMinutes(str){
+  const m = str.trim().toLowerCase().match(/(\d{1,2})(?:(?:\:|\s*h\s*)(\d{2}))?\s*(am|pm)?/);
+  if(!m) return 0;
+  let h=+m[1];
+  const mins=m[2]?+m[2]:0;
+  const ap=m[3];
+  if(ap){
+    if(ap==='pm' && h!==12) h+=12;
+    if(ap==='am' && h===12) h=0;
+  }
+  return h*60+mins;
+}
+
+const samples = [
+  'from 9:00 to 10:00 Meeting',
+  'de 9h00 à 10h00 Réunion'
+];
+
+samples.forEach(text => {
+  const m = text.match(regex);
+  if (m) {
+    const [, start, end, title] = m;
+    const duration = toMinutes(end) - toMinutes(start);
+    console.log(`Parsed "${text}" ->`, { start, end, title, duration });
+  } else {
+    console.log(`No match for "${text}"`);
+  }
+});


### PR DESCRIPTION
## Summary
- add `h` as an accepted separator between hours and minutes
- update duration parsing for `9h00` formats
- include a small example script showing detection of `9:00` and `9h00`

## Testing
- `node regex_examples.js`


------
https://chatgpt.com/codex/tasks/task_e_68480f4a7c288323b0f8db9ed834a4a1