### PR TITLE
Handle overnight meetings

### DIFF
--- a/content.js
+++ b/content.js
@@ -62,7 +62,8 @@ function parseEventsFromWeekView() {
       }
       return h * 60 + mins;
     }
-    const duration = toMinutes(end) - toMinutes(start);
+    let duration = toMinutes(end) - toMinutes(start);
+    if (duration < 0) duration += 24 * 60; // handle overnight meetings
     parsed.push({ title: title.trim(), duration, date, dayOfWeek, dayName });
   });
   return parsed;


### PR DESCRIPTION
## Summary
- fix duration parsing for meetings that cross midnight

## Testing
- `npm test` *(fails: `package.json` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68481026cd788323af8f080b18b042fa