### PR TITLE
Fix event title parsing

### DIFF
--- a/content.js
+++ b/content.js
@@ -42,7 +42,11 @@ function parseEventsFromWeekView() {
       dayOfWeek = d.getDay();
       dayName = d.toLocaleDateString('en-US', { weekday: 'long' });
     }
-    const cleanTitle = rawTitle.replace(/\s*•.*$/, '').split('\n')[0].trim();
+    let cleanTitle = rawTitle.replace(/\s*•.*$/, '').split('\n')[0].trim();
+    const commaIdx = cleanTitle.indexOf(',');
+    if (commaIdx !== -1) {
+      cleanTitle = cleanTitle.slice(0, commaIdx).trim();
+    }
     const lowerTitle = cleanTitle.toLowerCase();
     if (
       lowerTitle.includes('planning de rendez-vous') ||


### PR DESCRIPTION
## Summary
- trim organizer and other details after the first comma in event titles

## Testing
- `node -c content.js`
- `node -c popup.js`


------
https://chatgpt.com/codex/tasks/task_e_684813e82bcc8323938576243331e3e2