### PR TITLE
Fix month detection and adjust summary UI

### DIFF
--- a/content.js
+++ b/content.js
@@ -7,6 +7,10 @@ function parseEventsFromWeekView() {
     "janvier","février","mars","avril","mai","juin","juillet",
     "août","septembre","octobre","novembre","décembre"
   ];
+  const monthOnlyRegex = new RegExp(
+    `^(?:${months.join('|')})(?:\\s+\\d{4})?$`,
+    'i'
+  );
 
   chips.forEach(chip => {
     const info = chip.querySelector('.XuJrye');
@@ -49,6 +53,7 @@ function parseEventsFromWeekView() {
     }
     const lowerTitle = cleanTitle.toLowerCase();
     if (
+      monthOnlyRegex.test(lowerTitle) ||
       lowerTitle.includes('planning de rendez-vous') ||
       lowerTitle.includes('lunch') ||
       lowerTitle.includes('déjeuner') ||

--- a/popup.html
+++ b/popup.html
@@ -17,6 +17,9 @@
     .tab-content { display: none; padding: 22px 18px 10px 18px; min-height: 290px; background: #fff; }
     .tab-content.active { display: block; }
     table { width: 100%; border-collapse: separate; border-spacing: 0; background: #fafbfc; margin-top: 12px; box-shadow: 0 1px 2px #e1e4ea44; border-radius: 8px; overflow: hidden; }
+    .summary-table th:first-child,
+    .summary-table td:first-child { width: 60%; }
+    .summary-table select { min-width: 70px; }
     th { background: #eef3f9; color: #444; font-weight: 500; font-size: 14px; border-bottom: 1px solid #e6eaf2; padding: 9px 8px; text-align: left; }
     td { padding: 7px 8px; border-bottom: 1px solid #f0f0f0; font-size: 14px; color: #222; vertical-align: middle; }
     tr:last-child td { border-bottom: none; }

--- a/popup.js
+++ b/popup.js
@@ -194,6 +194,7 @@ async function loadSummary() {
           .map(([title, mins]) => [title, mins])
           .sort((a, b) => b[1] - a[1]);
         const table = document.createElement('table');
+        table.className = 'summary-table';
         const header = document.createElement('tr');
         header.innerHTML = "<th>Meeting</th><th>Hours</th><th>Project</th>";
         table.appendChild(header);
@@ -274,6 +275,7 @@ async function loadSummary() {
         label.textContent = DAYS_LABEL[DAYS_EN.indexOf(filter)];
         container.appendChild(label);
         const table = document.createElement('table');
+        table.className = 'summary-table';
         const header = document.createElement('tr');
         header.innerHTML = "<th>Meeting</th><th>Hours</th><th>Project</th>";
         table.appendChild(header);


### PR DESCRIPTION
## Summary
- avoid treating month names as events
- make event column wider and dropdown narrower in summary
- tag summary tables with CSS class

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684815d21c788323abb4d323911c2cce