### PR TITLE
Adjust column layout in summary

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,9 @@
     .tab-content { display: none; padding: 22px 18px 10px 18px; min-height: 290px; background: #fff; }
     .tab-content.active { display: block; }
     table { width: 100%; border-collapse: separate; border-spacing: 0; background: #fafbfc; margin-top: 12px; box-shadow: 0 1px 2px #e1e4ea44; border-radius: 8px; overflow: hidden; }
+    .summary-table { table-layout: fixed; }
     .summary-table th:first-child,
-    .summary-table td:first-child { width: 60%; }
+    .summary-table td:first-child { width: 60%; word-break: break-word; }
     .summary-table select { min-width: 70px; }
     th { background: #eef3f9; color: #444; font-weight: 500; font-size: 14px; border-bottom: 1px solid #e6eaf2; padding: 9px 8px; text-align: left; }
     td { padding: 7px 8px; border-bottom: 1px solid #f0f0f0; font-size: 14px; color: #222; vertical-align: middle; }


### PR DESCRIPTION
## Summary
- tweak layout for summary table so event titles can use ~60% width

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68481ff0f2ec83238dc402bf32d675fd