### PR TITLE
Fix summary project column overflow

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -17,7 +17,7 @@
     .tab-content { display: none; padding: 22px 18px 10px 18px; min-height: 290px; background: #fff; }
     .tab-content.active { display: block; }
     table { width: 100%; border-collapse: separate; border-spacing: 0; background: #fafbfc; margin-top: 12px; box-shadow: 0 1px 2px #e1e4ea44; border-radius: 8px; overflow: hidden; }
-    .summary-table { table-layout: fixed; }
+    .summary-table { table-layout: fixed; overflow: visible; }
     .summary-table th:first-child,
     .summary-table td:first-child { width: 60%; word-break: break-word; }
     .summary-table select { min-width: 70px; }


### PR DESCRIPTION
## Summary
- allow overflow for summary table so project dropdowns display correctly

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848214348a483238390d6e9948a396c