### PR TITLE
Remove unused scripting permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Weekly Calendar Project Tracker",
   "version": "2.1",
   "description": "Track, color-code, and export your Google Calendar meetings and project hours by week or day.",
-  "permissions": ["scripting", "activeTab", "storage"],
+  "permissions": ["activeTab", "storage"],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {


### PR DESCRIPTION
## Summary
- remove unused `scripting` permission from extension manifest

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a8e925a748323b77df8b289e768b2