### PR TITLE
Fix Add to Everhour button layout

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -8,7 +8,7 @@
       font-family: 'Segoe UI', 'Inter', Arial, sans-serif;
       background: #f8f9fa;
       margin: 0;
-      min-width: 420px;
+      min-width: 460px;
       min-height: 430px;
     }
     #tabs { display: flex; border-bottom: 1px solid #e1e4ea; background: #fff; }
@@ -28,6 +28,7 @@
     .summary-table td:nth-child(4) { width: 15%; }
     .summary-table select { min-width: 100px; width: 100%; }
     .summary-table button { width: 100%; }
+    .everhour-btn { width: 28px; padding: 4px; font-weight:bold; }
     th { background: #eef3f9; color: #444; font-weight: 500; font-size: 14px; border-bottom: 1px solid #e6eaf2; padding: 9px 8px; text-align: left; }
     td { padding: 7px 8px; border-bottom: 1px solid #f0f0f0; font-size: 14px; color: #222; vertical-align: middle; }
     tr:last-child td { border-bottom: none; }

--- a/popup.js
+++ b/popup.js
@@ -248,7 +248,7 @@ async function sendToEverhour(title, eventsArr, assignedProject, btn) {
     btn.textContent = 'Error';
   }
   setTimeout(() => {
-    btn.textContent = 'Add to Everhour';
+    btn.textContent = '+';
     btn.disabled = false;
   }, 2000);
 }
@@ -319,7 +319,9 @@ async function loadSummary() {
           tr.appendChild(td);
           const addTd = document.createElement('td');
           const addBtn = document.createElement('button');
-          addBtn.textContent = 'Add to Everhour';
+          addBtn.className = 'everhour-btn';
+          addBtn.textContent = '+';
+          addBtn.title = 'Add to Everhour';
           addBtn.style.marginTop = '0';
           const titleEvents = events.filter(ev => ev.title === title);
           addBtn.onclick = () => sendToEverhour(title, titleEvents, assignedProject, addBtn);
@@ -405,7 +407,9 @@ async function loadSummary() {
           tr.appendChild(td);
           const addTd = document.createElement('td');
           const addBtn = document.createElement('button');
-          addBtn.textContent = 'Add to Everhour';
+          addBtn.className = 'everhour-btn';
+          addBtn.textContent = '+';
+          addBtn.title = 'Add to Everhour';
           addBtn.style.marginTop = '0';
           const titleEvents = filteredEvents.filter(ev => ev.title === title);
           addBtn.onclick = () => sendToEverhour(title, titleEvents, assignedProject, addBtn);


### PR DESCRIPTION
## Summary
- widen popup UI slightly
- replace long 'Add to Everhour' label with a compact '+' button
- style Everhour button via new `.everhour-btn` class

## Testing
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_686d081ecbd88323baa24f646478073a