### PR TITLE
Add option to open settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 ## 🚀 How to Use
 
 1. Open [Google Calendar](https://calendar.google.com) in **Week View**
-2. Click the extension icon (or right-click it and choose **Options** to open the Settings page in a new tab)
+2. Click the extension icon (use **Options** or the **Open Settings Page** button in the Settings tab for a full-page view)
 3. Use the **Summary** tab to assign meetings to projects
 4. View project totals in the **Project Hours** tab
 5. Export your data if needed for reporting
-6. In the **Settings** tab or **Options** page, enter your Everhour API token and each project's task ID
-
+6. In the **Settings** tab or full Settings page, enter your Everhour API token and each project's task ID
 > Tip: Add custom **keywords** when creating projects to auto-link new meetings in future weeks.
 
 ## 🗂 Tabs Overview

--- a/popup.html
+++ b/popup.html
@@ -95,6 +95,7 @@
       <input type="text" id="everhour-token" placeholder="Token" class="task-input" autocomplete="off"/>
       <button id="save-token">Save</button>
       <span id="token-status" style="font-size:12px;margin-left:6px;"></span>
+    <button id="open-options" style="margin-top:10px;">Open Settings Page</button>
     </div>
   </div>
 

--- a/popup.js
+++ b/popup.js
@@ -92,6 +92,7 @@ async function saveEverhourToken() {
   }
 }
 document.getElementById('save-token').onclick = saveEverhourToken;
+document.getElementById('open-options').onclick = () => { chrome.runtime.openOptionsPage(); };
 loadEverhourToken();
 
 // --- PROJECTS CRUD ---


### PR DESCRIPTION
## Summary
- add a button in the popup settings tab to open the options page
- wire button to `chrome.runtime.openOptionsPage()`
- update README instructions about opening the settings page

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686f8b730448832397990559115a839f