### PR TITLE
Add comment from title suffix with plus sign

### DIFF
--- a/content.js
+++ b/content.js
@@ -51,6 +51,12 @@ function parseEventsFromWeekView() {
     if (commaIdx !== -1) {
       cleanTitle = cleanTitle.slice(0, commaIdx).trim();
     }
+    let comment = '';
+    const plusIdx = cleanTitle.indexOf('+');
+    if (plusIdx !== -1) {
+      comment = cleanTitle.slice(plusIdx + 1).trim();
+      cleanTitle = cleanTitle.slice(0, plusIdx).trim();
+    }
     const lowerTitle = cleanTitle.toLowerCase();
     if (
       monthOnlyRegex.test(lowerTitle) ||
@@ -80,6 +86,7 @@ function parseEventsFromWeekView() {
       String(startMinutes % 60).padStart(2, '0');
     parsed.push({
       title: cleanTitle,
+      comment,
       duration,
       date,
       dayOfWeek,

--- a/popup.js
+++ b/popup.js
@@ -245,7 +245,7 @@ async function sendToEverhour(title, eventsArr, assignedProject, btn) {
   btn.textContent = 'Sending...';
   try {
     for (const ev of eventsToSend) {
-      const { date, duration } = ev;
+      const { date, duration, comment = '' } = ev;
       const res = await fetch(`https://api.everhour.com/tasks/${taskId}/time`, {
         method: 'POST',
         headers: {
@@ -255,7 +255,8 @@ async function sendToEverhour(title, eventsArr, assignedProject, btn) {
         body: JSON.stringify({
           task: taskId,
           date,
-          time: Math.round(duration * 60)
+          time: Math.round(duration * 60),
+          comment
         })
       });
       if (!res.ok) {

--- a/regex_examples.js
+++ b/regex_examples.js
@@ -20,9 +20,15 @@ const samples = [
 samples.forEach(text => {
   const m = text.match(regex);
   if (m) {
-    const [, start, end, title] = m;
+    let [, start, end, title] = m;
+    let comment = '';
+    const plusIdx = title.indexOf('+');
+    if (plusIdx !== -1) {
+      comment = title.slice(plusIdx + 1).trim();
+      title = title.slice(0, plusIdx).trim();
+    }
     const duration = toMinutes(end) - toMinutes(start);
-    console.log(`Parsed "${text}" ->`, { start, end, title, duration });
+    console.log(`Parsed "${text}" ->`, { start, end, title, duration, comment });
   } else {
     console.log(`No match for "${text}"`);
   }

--- a/test.js
+++ b/test.js
@@ -39,9 +39,15 @@ function toMinutes(str) {
 function parseSample(text) {
   const m = text.match(regex);
   if(!m) return null;
-  const [, start, end, title] = m;
+  let [, start, end, title] = m;
+  let comment = '';
+  const plusIdx = title.indexOf('+');
+  if(plusIdx !== -1){
+    comment = title.slice(plusIdx + 1).trim();
+    title = title.slice(0, plusIdx).trim();
+  }
   const duration = toMinutes(end) - toMinutes(start);
-  return { start, end, title, duration };
+  return { start, end, title, duration, comment };
 }
 
 // Tests for quoteField
@@ -55,10 +61,14 @@ assert.strictEqual(addAlpha('#ff0000', 0.5), 'rgba(255, 0, 0, 0.5)');
 assert.strictEqual(addAlpha('#00ff00', 1), 'rgba(0, 255, 0, 1)');
 
 // Regex parsing tests
+
 let p = parseSample('from 9:00 to 10:00 Meeting');
-assert.deepStrictEqual(p, { start:'9:00 ', end:'10:00 ', title:'Meeting', duration:60 });
+assert.deepStrictEqual(p, { start:'9:00 ', end:'10:00 ', title:'Meeting', duration:60, comment:'' });
 
 p = parseSample('de 9h00 à 10h00 Réunion');
-assert.deepStrictEqual(p, { start:'9h00 ', end:'10h00 ', title:'Réunion', duration:60 });
+assert.deepStrictEqual(p, { start:'9h00 ', end:'10h00 ', title:'Réunion', duration:60, comment:'' });
+
+p = parseSample('from 9:00 to 10:00 Meeting + Notes');
+assert.deepStrictEqual(p, { start:'9:00 ', end:'10:00 ', title:'Meeting', duration:60, comment:'Notes' });
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- allow meeting titles to contain a `+` followed by a comment
- send that comment to Everhour when logging time
- update regex example and tests for comment parsing

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6881e7469fac8323b1592b6703eda9db