### PR TITLE
Enable tooltip for project dropdown

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -326,12 +326,14 @@ async function loadSummary() {
           const sel = document.createElement('select');
           sel.innerHTML = '<option value="">-</option>' +
             projects.map(p => `<option value="${p.name}" style="background:${p.color};" ${assignedProject === p.name ? "selected" : ""}>${p.name}</option>`).join('');
+          sel.title = sel.options[sel.selectedIndex]?.text || '';
           sel.onchange = async () => {
             map[title] = sel.value;
             assignedProject = sel.value;
             const proj = projects.find(p => p.name === sel.value);
             if (proj) tr.style.background = addAlpha(proj.color, 0.2);
             else tr.style.background = '';
+            sel.title = sel.options[sel.selectedIndex]?.text || '';
             await setMeetingToProjectMap(map);
           };
           if (assignedProject) {
@@ -418,12 +420,14 @@ async function loadSummary() {
           const sel = document.createElement('select');
           sel.innerHTML = '<option value="">-</option>' +
             projects.map(p => `<option value="${p.name}" style="background:${p.color};" ${assignedProject === p.name ? "selected" : ""}>${p.name}</option>`).join('');
+          sel.title = sel.options[sel.selectedIndex]?.text || '';
           sel.onchange = async () => {
             map[title] = sel.value;
             assignedProject = sel.value;
             const proj = projects.find(p => p.name === sel.value);
             if (proj) tr.style.background = addAlpha(proj.color, 0.2);
             else tr.style.background = '';
+            sel.title = sel.options[sel.selectedIndex]?.text || '';
             await setMeetingToProjectMap(map);
           };
           if (assignedProject) {


### PR DESCRIPTION
## Summary
- show the selected project name as a tooltip for summary table dropdowns

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6881ea3846948323999846a5b340ed08