### PR TITLE
Remove CSV export and refine settings UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Calendar to Project Hours – Chrome Extension
 
-A lightweight Chrome extension that helps you track and summarize your Google Calendar meetings by project. It auto-detects meetings, links them to projects, and exports weekly or daily hour summaries to make time tracking faster and easier.
+A lightweight Chrome extension that helps you track and summarize your Google Calendar meetings by project. It auto-detects meetings, links them to projects, and lets you quickly log time to Everhour.
 
 ## 🔧 Features
 
@@ -10,7 +10,6 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 - **Auto-links** recurring meetings to their projects using custom keywords
 - **Color-code** each project for clarity
 - Shows total hours per **project**, per **day**, or **per week**
-- Export summaries as **CSV** files (per week, per day, or across weeks)
 - Quickly send a meeting's time to **Everhour**
 - Simple **onboarding tooltip** to get started
 - Modern, clean UI
@@ -21,8 +20,7 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 2. Click the extension icon (use **Options** or the **Open Settings Page** button in the Settings tab for a full-page view)
 3. Use the **Summary** tab to assign meetings to projects
 4. View project totals in the **Project Hours** tab
-5. Export your data if needed for reporting
-6. In the **Settings** tab or full Settings page, enter your Everhour API token and each project's task ID
+5. In the **Settings** tab or full Settings page, enter your Everhour API token and each project's task ID
 > Tip: Add custom **keywords** when creating projects to auto-link new meetings in future weeks.
 
 ## 🗂 Tabs Overview
@@ -38,12 +36,6 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 3. Enable **Developer Mode**
 4. Click **Load unpacked**
 5. Select the folder with this extension
-
-## 📤 Export Formats
-
-- `weekly_calendar_summary.csv`
-- `project_hours_summary.csv`
-- Daily versions like `calendar_monday.csv`, etc.
 
 ## ✅ Requirements
 

--- a/options.html
+++ b/options.html
@@ -6,10 +6,21 @@
   <style>
     body {
       font-family: 'Segoe UI', 'Inter', Arial, sans-serif;
-      background: #f8f9fa;
+      background: #f0f2f5;
       margin: 0;
       min-width: 460px;
       min-height: 430px;
+      display: flex;
+      justify-content: center;
+      padding: 20px 0;
+    }
+    #settings-wrapper {
+      width: 100%;
+      max-width: 620px;
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+      padding: 20px;
     }
     #tabs { display: flex; border-bottom: 1px solid #e1e4ea; background: #fff; }
     .tab { flex: 1; padding: 12px 0 10px 0; cursor: pointer; border: none; background: none; font-size: 15px; color: #777; transition: color 0.15s; text-align: center; letter-spacing: 0.03em; }
@@ -40,7 +51,7 @@
     button, select, input[type="text"], input[type="color"] { font-size: 14px; border-radius: 6px; border: 1px solid #bfc6d2; background: #f4f7fa; color: #1d273b; outline: none; margin-top: 10px; margin-bottom: 4px; padding: 6px 14px; transition: border 0.13s; }
     button { background: #4f8cff; color: #fff; border: none; margin-top: 16px; cursor: pointer; font-weight: 500; padding: 8px 18px; box-shadow: 0 1px 2px #4f8cff11; transition: background 0.18s; }
     button:hover { background: #356cd2; }
-    #add-project, #export, #export-hours { margin-left: 4px; margin-top: 10px; }
+    #add-project { margin-left: 4px; margin-top: 10px; }
     select { background: #fff; border: 1px solid #bfc6d2; min-width: 90px; margin-left: 4px; margin-top: 0; height: 32px; }
     input[type="text"] { padding: 7px 12px; width: 60%; background: #fff; margin-right: 4px; }
     .delete-btn { color: #c52929; background: #fff; border: 1px solid #ebebeb; margin-left: 9px; padding: 3px 10px; font-size: 13px; border-radius: 4px; transition: background 0.16s; }
@@ -59,8 +70,9 @@
   </style>
 </head>
 <body>
-  <h2 style="margin:0; padding:16px;">Settings</h2>
-  <div id="settings" class="tab-content active">
+  <div id="settings-wrapper">
+    <h2 style="margin-top:0;">Settings</h2>
+    <div id="settings" class="tab-content active" style="padding:0;">
     <div>
       <input type="text" id="new-project" placeholder="New project name" autocomplete="off"/>
       <input type="color" id="new-project-color" value="#42a5f5" title="Project color"/>
@@ -75,15 +87,6 @@
       <button id="save-token">Save</button>
       <span id="token-status" style="font-size:12px;margin-left:6px;"></span>
     </div>
-    <div style="margin-top:20px;">
-      <label for="export-range" style="font-size:13px;">Export hours:</label>
-      <select id="export-range" style="margin-left:6px;">
-        <option value="week">Week</option>
-        <option value="month">Month</option>
-        <option value="year">Year</option>
-        <option value="all">All</option>
-      </select>
-      <button id="export-hours" style="margin-left:4px;">Export CSV</button>
     </div>
   </div>
   <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -5,13 +5,6 @@ const storage = {
   remove: key => new Promise(res => chrome.storage.local.remove(key, res)),
 };
 
-function quoteField(value) {
-  const str = String(value ?? '');
-  if(/[",\n]/.test(str)) {
-    return '"' + str.replace(/"/g, '""') + '"';
-  }
-  return str;
-}
 
 // Load and save Everhour token
 async function loadEverhourToken() {
@@ -138,36 +131,6 @@ document.getElementById('add-project').onclick = async () => {
   document.getElementById('new-project-task').value = '';
 };
 
-// Export hours (week only)
-document.getElementById('export-hours').onclick = () => {
-  const range = document.getElementById('export-range').value;
-  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
-    chrome.tabs.sendMessage(tabs[0].id, 'get_week_events', async events => {
-      if (!Array.isArray(events) || !events.length) {
-        alert('No events found. Open Google Calendar in Week View.');
-        return;
-      }
-      const { meetingProjectMap = {} } = await storage.get('meetingProjectMap');
-      const totals = {};
-      for (const ev of events) {
-        const project = meetingProjectMap[ev.title] || '';
-        if (!project) continue;
-        totals[project] = (totals[project] || 0) + ev.duration;
-      }
-      const rows = Object.entries(totals).map(([p, mins]) => [p, Math.round((mins / 60) * 100) / 100]);
-      const csvRows = [['Project', 'Hours']];
-      rows.forEach(r => csvRows.push(r));
-      const csv = csvRows.map(r => r.map(quoteField).join(',')).join('\r\n');
-      const blob = new Blob([csv], { type: 'text/csv' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `hours_${range}.csv`;
-      a.click();
-      URL.revokeObjectURL(url);
-    });
-  });
-};
 
 // Init
 loadEverhourToken();

--- a/popup.js
+++ b/popup.js
@@ -113,6 +113,7 @@ async function sendToEverhour(title, eventsArr, assignedProject, btn) {
     return;
   }
   btn.disabled = true;
+  const prev = btn.dataset.sent === 'true' ? '✓' : '+';
   btn.textContent = 'Sending...';
   try {
     for (const ev of eventsToSend) {
@@ -134,15 +135,18 @@ async function sendToEverhour(title, eventsArr, assignedProject, btn) {
         throw new Error('Request failed');
       }
     }
-    btn.textContent = 'Added!';
+    btn.dataset.sent = 'true';
+    btn.textContent = '✓';
+    btn.disabled = false;
   } catch (e) {
     console.error(e);
     btn.textContent = 'Error';
+    setTimeout(() => {
+      btn.textContent = prev;
+      btn.disabled = false;
+    }, 2000);
+    return;
   }
-  setTimeout(() => {
-    btn.textContent = '+';
-    btn.disabled = false;
-  }, 2000);
 }
 
 // --- SUMMARY TAB ---


### PR DESCRIPTION
## Summary
- drop export hours options
- tidy up settings page layout
- show a checkmark after sending entries to Everhour
- update README docs

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6881ed9e3aa88323b915a2a97bedb545