### PR TITLE
Add project grouping and reorder controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 - Quickly send a meeting's time to **Everhour**
 - Simple **onboarding tooltip** to get started
 - Modern, clean UI
+- Reorder and group projects in settings
 
 ## 🚀 How to Use
 
@@ -27,7 +28,7 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 
 - **Summary** – See and tag this week’s meetings
 - **Project Hours** – View total hours per project (weekly or daily)
-- **Settings** – Create, rename, color, or delete projects and keywords
+- **Settings** – Create, rename, color, reorder, group, or delete projects and keywords
 
 ## 💾 Installation
 

--- a/options.html
+++ b/options.html
@@ -38,6 +38,7 @@
       <input type="color" id="new-project-color" value="#42a5f5" title="Project color"/>
       <input type="text" id="new-project-keywords" placeholder="Keywords, comma-separated" class="keyword-input" autocomplete="off"/>
       <input type="text" id="new-project-task" placeholder="Task ID" class="task-input" autocomplete="off"/>
+      <input type="text" id="new-project-group" placeholder="Group" class="group-input" autocomplete="off"/>
       <button id="add-project">Add</button>
     </div>
     <ul id="project-list"></ul>

--- a/styles.css
+++ b/styles.css
@@ -51,5 +51,9 @@ input[type="text"] { padding: 7px 12px; width: 60%; background: #fff; margin-rig
 .keyword-input { width:110px; margin-left: 4px;}
 .rename-input { width:95px; margin-right: 4px;}
 .task-input { width:90px; margin-left: 4px; }
+.group-input { width:90px; margin-left: 4px; }
+.group-header { font-weight:bold; margin-top:10px; }
+.move-btn { background:#fff;border:1px solid #bfc6d2;color:#333;padding:3px 6px;font-size:12px;margin-left:4px; }
+.move-btn:hover { background:#f0f2f5; }
 .onboarding-tip { background: #e3edfa; color: #294365; font-size: 14px; padding: 10px 14px; border-radius: 7px; margin-bottom: 13px; border: 1px solid #aacee6; }
 .edit-btn, .save-btn, .cancel-btn { margin-left: 6px; font-size:12px; padding:3px 7px; }


### PR DESCRIPTION
## Summary
- allow adding group when creating or editing projects
- show group headers and move up/down buttons in the settings list
- clear new group field on add
- document new grouping and reordering feature

## Testing
- `node -c options.js`
- `node -c popup.js`
- `node -c content.js`
- `node test.js` *(fails: Identifier 'fs' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6887431bcf548323ba0643e317c7243c