### PR TITLE
Add How-to-use wiki docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Run `node test.js` to check script syntax and sample parsing. Node.js must be in
 
 ## 📚 Documentation
 
-Additional usage tips and troubleshooting guides are available in the [project wiki](wiki/Home.md).
+Additional usage tips and troubleshooting guides are available in the [project wiki](wiki/Home.md). The primary usage instructions are also mirrored in [wiki/How-to-use.md](wiki/How-to-use.md).
 
 ## Development Notes
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,6 +2,7 @@
 
 This wiki contains supplementary documentation for the Calendar to Project Hours extension.
 
+- [How to Use](How-to-use.md): Step-by-step guide for logging your calendar events.
 - [Projects](Projects.md): Learn how to manage, group and reorder projects.
 
 Use the sidebar to navigate through the available pages.

--- a/wiki/How-to-use.md
+++ b/wiki/How-to-use.md
@@ -1,0 +1,12 @@
+# How to Use
+
+Follow these steps to start tracking your calendar with Everhour:
+
+1. Open [Google Calendar](https://calendar.google.com) in **Week View**.
+2. Click the extension icon (or open the full Settings page from the Options menu).
+3. On the **Summary** tab, assign meetings to projects.
+4. See totals in the **Project Hours** tab.
+5. In **Settings**, provide your Everhour API token and each project's task ID.
+   > Tip: Add custom **keywords** when creating projects to automatically tag future meetings.
+
+See the [Projects](Projects.md) page to learn how to organize and reorder your projects.


### PR DESCRIPTION
## Summary
- add new wiki page on usage with project link
- link How-to-use page from wiki home
- reference new wiki page in README

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68874a1654cc8323a9c35c99adff2325