### PR TITLE
Add export settings button

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 - Simple **onboarding tooltip** to get started
 - Modern, clean UI
 - Reorder and group projects in settings
+- Export your settings and projects (excluding the API token)
 
 ## 🚀 How to Use
 

--- a/options.html
+++ b/options.html
@@ -50,6 +50,8 @@
     </div>
     <h3 style="margin-top:20px;">Activity Log</h3>
     <ul id="log-list" style="list-style:none;padding:8px;border:1px solid #e1e4ea;border-radius:6px;max-height:150px;overflow-y:auto;font-size:13px;"></ul>
+    <button id="export-settings" style="margin-top:10px;">Export Data</button>
+    <a id="download-link" style="display:none;"></a>
     </div>
   </div>
   <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -190,6 +190,21 @@ document.getElementById('add-project').onclick = async () => {
   document.getElementById('new-project-group').value = '';
 };
 
+// Export settings without API token
+async function exportSettings() {
+  const data = await storage.get(null);
+  delete data.everhourToken;
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.getElementById('download-link');
+  link.href = url;
+  link.download = 'settings_export.json';
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  addLog('Exported settings');
+}
+document.getElementById('export-settings').onclick = exportSettings;
+
 
 // Init
 loadEverhourToken();


### PR DESCRIPTION
## Summary
- add Export Data button in options page
- export local storage to JSON excluding API key
- document export feature in README

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6887d1b1c59483239d27fcf1c64aca3e