### PR TITLE
Add settings import option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 - Modern, clean UI
 - Reorder and group projects in settings
 - Export your settings and projects (excluding the API token)
+- Import settings from a JSON export file
 
 ## 🚀 How to Use
 
@@ -23,6 +24,7 @@ A lightweight Chrome extension that helps you track and summarize your Google Ca
 3. Use the **Summary** tab to assign meetings to projects
 4. View project totals in the **Project Hours** tab
 5. In the **Settings** tab or full Settings page, enter your Everhour API token and each project's task ID
+6. Use the **Export Data** and **Import** buttons to back up or restore your settings
 > Tip: Add custom **keywords** when creating projects to auto-link new meetings in future weeks.
 
 ## 🗂 Tabs Overview

--- a/options.html
+++ b/options.html
@@ -51,6 +51,8 @@
     <h3 style="margin-top:20px;">Activity Log</h3>
     <ul id="log-list" style="list-style:none;padding:8px;border:1px solid #e1e4ea;border-radius:6px;max-height:150px;overflow-y:auto;font-size:13px;"></ul>
     <button id="export-settings" style="margin-top:10px;">Export Data</button>
+    <input type="file" id="import-file" accept="application/json" style="margin-left:6px;" />
+    <button id="import-settings">Import</button>
     <a id="download-link" style="display:none;"></a>
     </div>
   </div>

--- a/options.js
+++ b/options.js
@@ -205,6 +205,34 @@ async function exportSettings() {
 }
 document.getElementById('export-settings').onclick = exportSettings;
 
+// Import settings from file and merge into storage, excluding API token
+async function importSettings() {
+  const fileInput = document.getElementById('import-file');
+  const file = fileInput.files[0];
+  if (!file) return;
+  let text = '';
+  try {
+    text = await file.text();
+  } catch (e) {
+    alert('Could not read file');
+    return;
+  }
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch (e) {
+    alert('Invalid JSON');
+    return;
+  }
+  delete data.everhourToken;
+  const current = await storage.get(null);
+  await storage.set({ ...current, ...data });
+  await addLog('Imported settings');
+  renderProjectList();
+  fileInput.value = '';
+}
+document.getElementById('import-settings').onclick = importSettings;
+
 
 // Init
 loadEverhourToken();


### PR DESCRIPTION
## Summary
- add a file input and Import button on the settings page
- support importing a JSON settings file in options.js
- log the import action
- document the feature and how to use it

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6887d7417b8c83238a10999ebf070d49