### PR TITLE
Improve settings UI layout

### DIFF
--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
       font-family: 'Segoe UI', 'Inter', Arial, sans-serif;
       background: #f0f2f5;
       margin: 0;
-      min-width: 460px;
+      min-width: 560px;
       min-height: 430px;
       display: flex;
       justify-content: center;
@@ -17,10 +17,11 @@
     }
     #settings-wrapper {
       width: 100%;
-      max-width: 620px;
+      max-width: 760px;
       background: #fff;
       border-radius: 8px;
-      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+      border: 1px solid #e1e4ea;
+      box-shadow: 0 3px 6px rgba(0,0,0,0.06);
       padding: 20px;
     }
     .summary-table select { min-width: 160px; width: 100%; }
@@ -32,28 +33,40 @@
 <body>
   <div id="settings-wrapper">
     <h2 style="margin-top:0;">Settings</h2>
-    <div id="settings" class="tab-content active" style="padding:0;">
-    <div>
-      <input type="text" id="new-project" placeholder="New project name" autocomplete="off"/>
-      <input type="color" id="new-project-color" value="#42a5f5" title="Project color"/>
-      <input type="text" id="new-project-keywords" placeholder="Keywords, comma-separated" class="keyword-input" autocomplete="off"/>
-      <input type="text" id="new-project-task" placeholder="Task ID" class="task-input" autocomplete="off"/>
-      <input type="text" id="new-project-group" placeholder="Group" class="group-input" autocomplete="off"/>
-      <button id="add-project">Add</button>
+    <div id="tabs">
+      <div class="tab active" data-tab="projects">Projects</div>
+      <div class="tab" data-tab="everhour">Everhour</div>
+      <div class="tab" data-tab="activity">Activity</div>
     </div>
-    <ul id="project-list"></ul>
-    <div style="margin-top:16px;">
+
+    <div id="projects" class="tab-content active" style="padding:0;">
+      <div>
+        <input type="text" id="new-project" placeholder="New project name" autocomplete="off"/>
+        <input type="color" id="new-project-color" value="#42a5f5" title="Project color"/>
+        <input type="text" id="new-project-keywords" placeholder="Keywords, comma-separated" class="keyword-input" autocomplete="off"/>
+        <input type="text" id="new-project-task" placeholder="Task ID" class="task-input" autocomplete="off"/>
+        <input type="text" id="new-project-group" placeholder="Group" class="group-input" autocomplete="off"/>
+        <button id="add-project">Add</button>
+      </div>
+      <ul id="project-list"></ul>
+    </div>
+
+    <div id="everhour" class="tab-content">
       <label for="everhour-token" style="font-size:13px;">Everhour API Token:</label>
       <input type="text" id="everhour-token" placeholder="Token" class="task-input" autocomplete="off"/>
       <button id="save-token">Save</button>
       <span id="token-status" style="font-size:12px;margin-left:6px;"></span>
+      <div style="margin-top:20px;">
+        <button id="export-settings" style="margin-top:0;">Export Data</button>
+        <button id="import-settings" style="margin-left:6px;margin-top:0;">Import</button>
+        <input type="file" id="import-file" accept="application/json" style="margin-left:6px;" />
+        <a id="download-link" style="display:none;"></a>
+      </div>
     </div>
-    <h3 style="margin-top:20px;">Activity Log</h3>
-    <ul id="log-list" style="list-style:none;padding:8px;border:1px solid #e1e4ea;border-radius:6px;max-height:150px;overflow-y:auto;font-size:13px;"></ul>
-    <button id="export-settings" style="margin-top:10px;">Export Data</button>
-    <input type="file" id="import-file" accept="application/json" style="margin-left:6px;" />
-    <button id="import-settings">Import</button>
-    <a id="download-link" style="display:none;"></a>
+
+    <div id="activity" class="tab-content">
+      <h3 style="margin-top:0;">Activity Log</h3>
+      <ul id="log-list" class="log-list"></ul>
     </div>
   </div>
   <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -5,6 +5,16 @@ const storage = {
   remove: key => new Promise(res => chrome.storage.local.remove(key, res)),
 };
 
+// --- TABS ---
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+    tab.classList.add('active');
+    document.getElementById(tab.dataset.tab).classList.add('active');
+  });
+});
+
 async function addLog(message) {
   const { logs = [] } = await storage.get('logs');
   logs.push({ msg: message, date: new Date().toLocaleString() });

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
-#tabs { display: flex; border-bottom: 1px solid #e1e4ea; background: #fff; }
-.tab { flex: 1; padding: 12px 0 10px 0; cursor: pointer; border: none; background: none; font-size: 15px; color: #777; transition: color 0.15s; text-align: center; letter-spacing: 0.03em; }
-.tab.active { color: #222; font-weight: bold; border-bottom: 2.5px solid #4f8cff; background: #f7fbff; }
-.tab-content { display: none; padding: 22px 18px 10px 18px; min-height: 290px; background: #fff; }
+#tabs { display: flex; border-bottom: 1px solid #e1e4ea; background: #fff; border-radius: 8px 8px 0 0; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
+.tab { flex: 1; padding: 12px 0 10px 0; cursor: pointer; border: none; background: none; font-size: 15px; color: #666; transition: color 0.15s; text-align: center; letter-spacing: 0.03em; }
+.tab.active { color: #222; font-weight: 600; border-bottom: 3px solid #4f8cff; background: linear-gradient(#f7fbff, #eef6ff); }
+.tab-content { display: none; padding: 22px 18px 10px 18px; min-height: 290px; background: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.04); border-radius: 0 0 8px 8px; }
 .tab-content.active { display: block; }
 table { width: 100%; border-collapse: separate; border-spacing: 0; background: #fafbfc; margin-top: 12px; box-shadow: 0 1px 2px #e1e4ea44; border-radius: 8px; overflow: hidden; }
 .summary-table { table-layout: fixed; overflow: visible; }
@@ -57,3 +57,4 @@ input[type="text"] { padding: 7px 12px; width: 60%; background: #fff; margin-rig
 .move-btn:hover { background:#f0f2f5; }
 .onboarding-tip { background: #e3edfa; color: #294365; font-size: 14px; padding: 10px 14px; border-radius: 7px; margin-bottom: 13px; border: 1px solid #aacee6; }
 .edit-btn, .save-btn, .cancel-btn { margin-left: 6px; font-size:12px; padding:3px 7px; }
+.log-list { list-style:none; padding:8px; border:1px solid #e1e4ea; border-radius:6px; max-height:150px; overflow-y:auto; font-size:13px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }


### PR DESCRIPTION
## Summary
- update options page with tabbed layout
- add soft shadows and borders
- style activity log and tabs
- increase page width and tweak import controls
- drop grey tab borders

## Testing
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_6887d9d81f48832382a004d0642d0a56