### PR TITLE
Fix settings CTA button alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -59,4 +59,5 @@ input[type="text"] { padding: 7px 12px; width: 60%; background: #fff; margin-rig
   padding: 3px 7px;
 }
 .edit-btn, .delete-btn, .move-btn { display: inline-flex; align-items: center; justify-content: center; }
+.delete-btn, .move-btn { margin-top: 0; }
 .log-list { list-style:none; padding:8px; border:1px solid #e1e4ea; border-radius:6px; max-height:150px; overflow-y:auto; font-size:13px; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }


### PR DESCRIPTION
## Summary
- keep edit/delete/move buttons vertically centered in settings

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6887ebf319848323bc02355e276bb536